### PR TITLE
Consider enforcing tabType and tabLength

### DIFF
--- a/settings/language-sml.cson
+++ b/settings/language-sml.cson
@@ -11,3 +11,5 @@
   'editor':
     'commentStart': '(*'
     'commentEnd': '*)'
+    'tabLength': 2
+    'tabType': 'soft'


### PR DESCRIPTION
Most SML style guides ask not to use hard tabs, this should be enforced from the package.

They also tend to suggest 2 or 3 spaced indentation, smaller the better for SML as code tends to get verbose fast. But I will let you decide whether to enforce tab length of type 2 or not.